### PR TITLE
kernel: fix off-by-one in syscall dispatch bound check

### DIFF
--- a/kernel/sched/syscall.c
+++ b/kernel/sched/syscall.c
@@ -7,7 +7,7 @@ syscall_handler_t syscalls[512] = {NULL};
 char *syscalls_name[512] = {NULL};
 
 void syscall_handle(struct syscall_arguments *args) {
-	if (args->syscall_nr > 512 || syscalls[args->syscall_nr] == NULL) {
+	if (args->syscall_nr >= 512 || syscalls[args->syscall_nr] == NULL) {
 		args->ret = -1;
 		errno = ENOSYS;
 		return;


### PR DESCRIPTION
closes #47

`syscalls[]` has 512 slots, valid indices are 0..511. check was `> 512` which let 512 through and indexed past the table into `syscalls_name[0]`, a string-literal pointer that the dispatcher then called.

one-line fix: `> 512` -> `>= 512`.

rationale + repro in #47.