### PR TITLE
kernel: fix shebang argv UAF and allocation size in process_execve

### DIFF
--- a/kernel/sched/sched.c
+++ b/kernel/sched/sched.c
@@ -593,15 +593,19 @@ bool process_execve(char *path, char **argv, char **envp) {
 		*c = '\0';
 		char **arg_list = NULL;
 		size_t arg_count = strsplit(shebang_line, ' ', &arg_list);
+		if (arg_count < 2) {
+			kfree(arg_list);
+			errno = ENOEXEC;
+			return false;
+		}
 		size_t old_arg_count = get_argv_length(argv);
 		char *new_path = arg_list[1];
 		char **new_argv =
-			kmalloc(sizeof(char *) * (arg_count + old_arg_count) + 2);
+			kmalloc(sizeof(char *) * (arg_count + old_arg_count + 2));
 		new_argv[0] = new_path;
 		new_argv[1] = path;
 		for (size_t i = 2; i < arg_count; i++) {
 			new_argv[i + 1] = arg_list[i];
-			kfree(arg_list[i]);
 		}
 		for (size_t i = 0; i < old_arg_count; i++) {
 			new_argv[i + arg_count + 1] = argv[i];


### PR DESCRIPTION
closes #49

two bugs in the shebang path:

1. `kmalloc(sizeof(char *) * (arg_count + old_arg_count) + 2)` is missing a pair of parens. allocation is 14 bytes short, the trailing NULL sentinel overruns the heap.
2. inside the copy loop each pointer is stored into `new_argv` then immediately `kfree`'d. the recursive `process_execve` then walks dangling pointers.

also added an `arg_count < 2` check so shebangs with no interpreter path return `ENOEXEC` instead of dereferencing `arg_list[1]` out of bounds.